### PR TITLE
Use after_action instead of after_filter

### DIFF
--- a/lib/validation_rage/rails.rb
+++ b/lib/validation_rage/rails.rb
@@ -36,7 +36,7 @@ module ValidationRage
           controller_class.send(:include, ValidationRage::ControllerExtension)
           options = {}
           options.merge({:only => actions}) unless actions.any? {|a| a == "*"}
-          controller_class.send(:after_filter, :notify_validation_rage, options)
+          controller_class.send(:after_action, :notify_validation_rage, options)
         end
       end
     end


### PR DESCRIPTION
after_filter was deprecated in rails 5.0 and remove in rails 5.1